### PR TITLE
group by spree_product.id instead of spree_favorites.id in order to fix query for postgresql for favorite query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
 
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree', '2.2.0'
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-2-stable'
+gem 'spree', github: 'spree/spree', branch: '2-3-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-3-stable'
+
 gem 'mysql2'
 
 group :assets do 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'spree_auth_devise', github: 'spree/spree_auth_devise'#, branch: '2-3-stable
 
 gem 'mysql2'
 
-group :assets do 
+group :assets do
   gem 'coffee-rails', '4.0.1'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree', github: 'spree/spree', branch: '2-3-stable'
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-3-stable'
+gem 'spree', github: 'spree/spree'#, branch: '2-3-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise'#, branch: '2-3-stable'
 
 gem 'mysql2'
 

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -3,9 +3,9 @@ Spree::Product.class_eval do
   has_many :favorite_users, :through => :favorites, :class_name => 'Spree::User', :source => 'user'
 
   def self.favorite
-    joins(:favorites).group('spree_favorites.product_id')
+    joins(:favorites).group('spree_products.id')
   end
-  
+
   def self.order_by_favorite_users_count(asc=false)
     order("count(spree_favorites.user_id) #{asc ? 'asc' : 'desc'}")
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # Run Coverage report
 require 'simplecov'
+require 'minitest/spec'
+require 'minitest/autorun'
+
 SimpleCov.start do
   add_group 'Controllers', 'app/controllers'
   add_group 'Helpers', 'app/helpers'

--- a/spree_favorite_products.gemspec
+++ b/spree_favorite_products.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2.0'
+  s.add_dependency 'spree_core', '~> 2.3.1'
 end

--- a/spree_favorite_products.gemspec
+++ b/spree_favorite_products.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.3.1'
+  s.add_dependency 'spree_core', '>= 2.3.1'
 end


### PR DESCRIPTION
On posgresql, group by clause have to be present in the select. 
So I had : ActionView::Template::Error (PG::GroupingError: ERROR:  column "spree_products.id" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: SELECT  "spree_products".\* FROM "spree_products" INNER JOIN ...
                ^
: SELECT  "spree_products".\* FROM "spree_products" INNER JOIN "spree_favorites" ON "spree_favorites"."product_id" = "spree_products"."id" WHERE "spree_products"."deleted_at" IS NULL GROUP BY spree_favorites.product_id  ORDER BY count(spree_favorites.user_id) desc LIMIT 25 OFFSET 0):
